### PR TITLE
Fixed compile errors and warnings; small cleanup

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -3,15 +3,15 @@
 //--------------------------------------------------------------
 void ofApp::setup(){
 
-	touch.init("/dev/input/event0");	// change according to your setup (evdev)
-	ofLog()<<touch.getName();
-	
+    touch.init("/dev/input/event0");    // change according to your setup (evdev)
+    ofLog()<<touch.getName();
+    
 }
 
 //--------------------------------------------------------------
 void ofApp::update(){
 /*
-	cout << "X: " << touch.getCoordTouch().x << endl
+    cout << "X: " << touch.getCoordTouch().x << endl
                   << "Y: " << touch.getCoordTouch().y << endl
                   << "BTN: " << touch.getButton() << endl
                   << "mtSlot: " << touch.getMTSlot() + 1 << endl
@@ -24,8 +24,8 @@ void ofApp::update(){
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-	
-	stringstream statusStream;
+    
+    stringstream statusStream;
     ofSetColor(255,255,255);
     
     statusStream << "X: " << touch.getCoordTouch().x << endl
@@ -38,7 +38,7 @@ void ofApp::draw(){
     << endl;
     ofDrawBitmapString(statusStream.str(),20,20);
 
-	
+    
 }
 
 //--------------------------------------------------------------
@@ -99,6 +99,6 @@ void ofApp::dragEvent(ofDragInfo dragInfo){
 //--------------------------------------------------------------
 void ofApp::exit(){
 
-	touch.exit();
+    touch.exit();
 
 }

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -5,26 +5,26 @@
 
 class ofApp : public ofBaseApp{
 
-	public:
-		void setup();
-		void update();
-		void draw();
+    public:
+        void setup();
+        void update();
+        void draw();
 
-		void exit();
+        void exit();
 
-		void keyPressed(int key);
-		void keyReleased(int key);
-		void mouseMoved(int x, int y );
-		void mouseDragged(int x, int y, int button);
-		void mousePressed(int x, int y, int button);
-		void mouseReleased(int x, int y, int button);
-		void mouseEntered(int x, int y);
-		void mouseExited(int x, int y);
-		void windowResized(int w, int h);
-		void dragEvent(ofDragInfo dragInfo);
-		void gotMessage(ofMessage msg);
+        void keyPressed(int key);
+        void keyReleased(int key);
+        void mouseMoved(int x, int y );
+        void mouseDragged(int x, int y, int button);
+        void mousePressed(int x, int y, int button);
+        void mouseReleased(int x, int y, int button);
+        void mouseEntered(int x, int y);
+        void mouseExited(int x, int y);
+        void windowResized(int w, int h);
+        void dragEvent(ofDragInfo dragInfo);
+        void gotMessage(ofMessage msg);
 
-		ofxRPiTouch touch;
-		vector <int> fingersFound;
+        ofxRPiTouch touch;
+        vector <int> fingersFound;
 
 };

--- a/src/ofxRPiTouch.h
+++ b/src/ofxRPiTouch.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "ofMain.h"
 #include <linux/input.h>
 #include <sys/ioctl.h>
@@ -7,40 +9,40 @@
 #include <fcntl.h>
 
 // SYN
-#define EVENT_TYPE_0	EV_SYN
+#define EVENT_TYPE_0    EV_SYN
 
 // KEY
-#define EVENT_TYPE_1	EV_KEY
-#define EVENT_CODE_330	BTN_TOUCH
-// Min	0
-// Max	1
+#define EVENT_TYPE_1    EV_KEY
+#define EVENT_CODE_330  BTN_TOUCH
+// Min  0
+// Max  1
 
 // TOUCH
 #define EVENT_TYPE      EV_ABS
 #define EVENT_CODE_0    ABS_X
-// Min	0
-// Max	800
+// Min  0
+// Max  800
 #define EVENT_CODE_1    ABS_Y
-// Min	0
-// Max	480
-#define EVENT_CODE_47 	ABS_MT_SLOT
-// Min	0
-// Max	9
-#define EVENT_CODE_53 	ABS_MT_POSITION_X
-// Min	0
-// Max	800
-#define EVENT_CODE_54 	ABS_MT_POSITION_Y
-// Min	0
-// Max	480
-#define EVENT_CODE_57 	ABS_MT_TRACKING_ID
-// Min	0
-// Max	65535
+// Min  0
+// Max  480
+#define EVENT_CODE_47   ABS_MT_SLOT
+// Min  0
+// Max  9
+#define EVENT_CODE_53   ABS_MT_POSITION_X
+// Min  0
+// Max  800
+#define EVENT_CODE_54   ABS_MT_POSITION_Y
+// Min  0
+// Max  480
+#define EVENT_CODE_57   ABS_MT_TRACKING_ID
+// Min  0
+// Max  65535
 
 //#define PORTRAIT_MODE
 //#define LANDSCAPE_MODE
 
 class ofxRPiTouch : public ofThread {
-	public:
+    public:
 
     struct input_event ev;
     int fd, size;
@@ -57,102 +59,114 @@ class ofxRPiTouch : public ofThread {
     //int screenH = 800;
 
 //-----------------------------------------------------------------------
-	int init(char * d) {
-		size = sizeof (struct input_event);
-		name[0]='U';
-		name[1]='n';
-		name[2]='k';
-		name[3]='n';
-		name[4]='o';
-		name[5]='w';
-		name[6]='n';
-		device = d;
+    int init(string d) {
+        size = sizeof (struct input_event);
+        name[0]='U';
+        name[1]='n';
+        name[2]='k';
+        name[3]='n';
+        name[4]='o';
+        name[5]='w';
+        name[6]='n';
+        device = &d[0];
 
-        	if ((fd = open(device, O_RDONLY)) < 0) {
-                	return 1;
-		}
-		startThread();
-	}
+        if ((fd = open(device, O_RDONLY)) < 0) {
+            return 1;
+        }
+        startThread();
+
+        return 0;
+    }
 //-----------------------------------------------------------------------
-	string getName(){
-		ioctl (fd, EVIOCGNAME (sizeof (name)), name);
-		string str(name);
-		return str;
-	}
+    string getName(){
+        ioctl (fd, EVIOCGNAME (sizeof (name)), name);
+        string str(name);
+        return str;
+    }
 //-----------------------------------------------------------------------
-	void exit(){
-		stopThread();
-	}
+    void exit(){
+        stopThread();
+    }
 //-----------------------------------------------------------------------
-	void threadedFunction(){
-		while(isThreadRunning()) {
-	        	const size_t ev_size = sizeof(struct input_event);
-		        ssize_t size;
-		        size = read(fd, &ev, ev_size);
-		        if (size < ev_size) {
-	        	    ofLog()<<"Error size!\n";
-		        }
+    void threadedFunction(){
+        while(isThreadRunning()) {
+            const size_t ev_size = sizeof(struct input_event);
+            ssize_t size;
+            size = read(fd, &ev, ev_size);
+            if (size < (ssize_t)ev_size) {
+                ofLog()<<"Error size!\n";
+            }
 
-			//KEY
-                        if (ev.type == EVENT_TYPE_1 && ev.code == EVENT_CODE_330){
-                                if(ev.code == EVENT_CODE_330)
-                                        button = ev.value;
-                        	        btn = button;
-                        }
+            //KEY
+            if (ev.type == EVENT_TYPE_1 && ev.code == EVENT_CODE_330){
+                if(ev.code == EVENT_CODE_330)
+                    button = ev.value;
+                btn = button;
+            }
 
-		        //TOUCH
-		        if (ev.type == EVENT_TYPE && ( ev.code == EVENT_CODE_0 || ev.code == EVENT_CODE_1 || ev.code == EVENT_CODE_47 || ev.code == EVENT_CODE_53 || ev.code == EVENT_CODE_54 || ev.code == EVENT_CODE_57 )) {
-			    	if(ev.code == EVENT_CODE_1)
-					x = ofMap(ev.value, 0,480,480,0);
-			    	if(ev.code == EVENT_CODE_0)
-					y = ofMap(ev.value, 0,800,0,800);
-					pos.set(x,y);
+            //TOUCH
+            if (ev.type == EVENT_TYPE && ( ev.code == EVENT_CODE_0 || ev.code == EVENT_CODE_1 || ev.code == EVENT_CODE_47 || ev.code == EVENT_CODE_53 || ev.code == EVENT_CODE_54 || ev.code == EVENT_CODE_57 )) {
+                if(ev.code == EVENT_CODE_1) {
+                    x = ofMap(ev.value, 0,480,480,0);
+                }
 
-				if (ev.code == EVENT_CODE_47)
-					mtSlot = ev.value;
-					mtSlt = mtSlot;
+                if(ev.code == EVENT_CODE_0) {
+                    y = ofMap(ev.value, 0,800,0,800);
+                }
 
-				if (ev.code == EVENT_CODE_53)
-					absMTPosX = ev.value;
-				if (ev.code == EVENT_CODE_54)
-					absMTPosY = ev.value;
-					absPos.set(absMTPosX,absMTPosY);
+                pos.set(x,y);
 
-				if (ev.code == EVENT_CODE_57)
-					absMTTrackingID = ev.value;
-					absTrackingID = absMTTrackingID;
-			}
-		}
-	}
-			//----------------------------
-				// Position
-				ofVec2f pos;
-				ofVec2f getCoordTouch(){
-					return pos;
-				}
-			//----------------------------
-				//Clicked
-				int btn;
-				int getButton(){
-					return btn;
-				}
-			//----------------------------
-				//Finger ID
-				int mtSlt;
-				int getMTSlot(){
-					return mtSlt;
-				}
-			//----------------------------
-				//Absolute Position
-				ofVec2f absPos;
-				ofVec2f getAbsPos(){
-					return absPos;
-				}
+                if (ev.code == EVENT_CODE_47) {
+                    mtSlot = ev.value;
+                    mtSlt = mtSlot;
+                }
 
-			//----------------------------
-				//Tracking ID
-				int absTrackingID;
-				int getAbsTrackingID(){
-					return absTrackingID;
-				}
+                if (ev.code == EVENT_CODE_53) {
+                    absMTPosX = ev.value;
+                }
+
+                if (ev.code == EVENT_CODE_54) {
+                    absMTPosY = ev.value;
+                }
+
+                absPos.set(absMTPosX,absMTPosY);
+
+                if (ev.code == EVENT_CODE_57) {
+                    absMTTrackingID = ev.value;
+                    absTrackingID = absMTTrackingID;
+                }
+            }
+        }
+    }
+//----------------------------
+    // Position
+    ofVec2f pos;
+    ofVec2f getCoordTouch(){
+        return pos;
+    }
+//----------------------------
+    //Clicked
+    int btn;
+    int getButton(){
+        return btn;
+    }
+//----------------------------
+    //Finger ID
+    int mtSlt;
+    int getMTSlot(){
+        return mtSlt;
+    }
+//----------------------------
+    //Absolute Position
+    ofVec2f absPos;
+    ofVec2f getAbsPos(){
+        return absPos;
+    }
+
+//----------------------------
+    //Tracking ID
+    int absTrackingID;
+    int getAbsTrackingID(){
+        return absTrackingID;
+    }
 };


### PR DESCRIPTION
The current repository does not compile with the default makefile
shipped with OpenFrameworks v0.10.0. This commit fixes the compile
error, and changes the mixed tabs and spaces to spaces, among other
small fixes to prevent compiler warnings.


Previous output:

```
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h: In member function ‘int ofxRPiTouch::init(char*)’:
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:75:2: error: control reaches end of non-void function [-Werror=return-type]
  }
  ^

In file included from /home/martijn/stack/doc/projects/deepFace/src/ofTouch.h:9:0,
                 from /home/martijn/stack/doc/projects/deepFace/src/ofTouch.cpp:1:
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h: In member function ‘virtual void ofxRPiTouch::threadedFunction()
’:
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:92:20: warning: comparison between signed and unsigned integer epressions [-Wsign-compare]
           if (size < ev_size) {
               ~~~~~^~~~~~~~~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:98:33: warning: this ‘if’ clause does not guard... [-Wmisleadingindentation]
                                 if(ev.code == EVENT_CODE_330)
                                 ^~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:100:34: note: ...this statement, but the latter is misleadingly $ndented as if it were guarded by the ‘if’
                                  btn = button;
                                  ^~~
In file included from /home/martijn/stack/doc/projects/deepFace/src/ofTouch.h:9:0,
                 from /home/martijn/stack/doc/projects/deepFace/src/ofTouch.cpp:1:
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:107:9: warning: this ‘if’ clause does not guard... [-Wmisleading$indentation]
         if(ev.code == EVENT_CODE_0)
         ^~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:109:6: note: ...this statement, but the latter is misleadingly i$dented as if it were guarded by the ‘if’
      pos.set(x,y);
      ^~~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:111:5: warning: this ‘if’ clause does not guard... [-Wmisleading$indentation]
     if (ev.code == EVENT_CODE_47)
     ^~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:113:6: note: ...this statement, but the latter is misleadingly i$
dented as if it were guarded by the ‘if’
      mtSlt = mtSlot;
      ^~~~~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:117:5: warning: this ‘if’ clause does not guard... [-Wmisleading$
indentation]
     if (ev.code == EVENT_CODE_54)
     ^~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:119:6: note: ...this statement, but the latter is misleadingly i$
dented as if it were guarded by the ‘if’
      absPos.set(absMTPosX,absMTPosY);
      ^~~~~~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:121:5: warning: this ‘if’ clause does not guard... [-Wmisleading$
indentation]
     if (ev.code == EVENT_CODE_57)
     ^~
/home/martijn/software/openframeworks/addons/ofxRPiTouch/src/ofxRPiTouch.h:123:6: note: ...this statement, but the latter is misleadingly i$
dented as if it were guarded by the ‘if’
      absTrackingID = absMTTrackingID;
      ^~~~~~~~~~~~~
```